### PR TITLE
Fix imports and dependencies

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,17 @@
+name: CompatHelper
+
+on:
+  schedule:
+    - cron: '00 00 * * *'
+
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}
+        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,33 @@
+# Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
-codecov: true
-coveralls: true
+branches:
+  only:
+    - master
 os:
   - linux
   - osx
 julia:
   - 1.0
-  - 1.2
+  - 1
+  - nightly
+matrix:
+  allow_failures:
+    - julia: nightly
+  fast_finish: true
 notifications:
   email: false
+after_success:
+  - if [[ $TRAVIS_JULIA_VERSION = 1 ]] && [[ $TRAVIS_OS_NAME = linux ]]; then
+      julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())';
+      julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())';
+    fi
 jobs:
   include:
     - stage: "Documentation"
-      julia: 1.2
+      julia: 1
       os: linux
       script:
         - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));
-                                               Pkg.build("InterpolatedPDFs");
                                                Pkg.instantiate()'
         - julia --project=docs/ docs/make.jl
-      after_success:
-        - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder()); Coveralls.submit(process_folder())'
+      after_success: skip

--- a/Project.toml
+++ b/Project.toml
@@ -8,14 +8,17 @@ Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 NumericalIntegration = "e7bfaba1-d571-5449-8927-abc22e82249b"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
+Distributions = "0.23"
+Interpolations = "0.12"
+NumericalIntegration = "0.2"
+StatsBase = "0.33"
 julia = "1"
 
 [extras]
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random"]
+test = ["Test"]

--- a/src/InterpolatedPDFs.jl
+++ b/src/InterpolatedPDFs.jl
@@ -5,14 +5,12 @@ using NumericalIntegration
 using StatsBase: midpoints
 
 using Interpolations
-using Interpolations: Extrapolation, GriddedInterpolation, BSplineInterpolation
+using Interpolations: getknots
 
 using Random: AbstractRNG
 
-export LinearInterpolatedPDF, fit_cpl, pdf, cdf, quantile, get_knots
+export LinearInterpolatedPDF, fit_cpl, pdf, cdf, quantile, getknots
 
 include("linear_1d.jl")
-
-#get_knots(d::LinearInterpolatedPDF) = d.pdf_itp
 
 end # module

--- a/src/InterpolatedPDFs.jl
+++ b/src/InterpolatedPDFs.jl
@@ -2,9 +2,12 @@ module InterpolatedPDFs
 
 using Distributions
 using NumericalIntegration
+using StatsBase: midpoints
 
 using Interpolations
 using Interpolations: Extrapolation, GriddedInterpolation, BSplineInterpolation
+
+using Random: AbstractRNG
 
 export LinearInterpolatedPDF, fit_cpl, pdf, cdf, quantile, get_knots
 

--- a/src/linear_1d.jl
+++ b/src/linear_1d.jl
@@ -99,6 +99,7 @@ invcdf_itp: 5-element extrapolate(interpolate((::Array{Float64,1},), ::Array{Flo
  1.1780972450961724
  1.5707963267948966
 )
+```
 """
 function fit_cpl(x::AbstractVector{XT}, s::AbstractVector{YT}) where {XT<:Real, YT<:Real}
     length(x) < 2 && error("need a minimum of 2 breakpoints")

--- a/src/linear_1d.jl
+++ b/src/linear_1d.jl
@@ -49,9 +49,9 @@ function LinearInterpolatedPDF(x, y)
     area = integrate(x,y)
     area ≈ 1 || error("Input is not normalized. integrate(x,y) = ", area)
     issorted(x) || error("x is not in ascending order")
-    
+
     pdf_itp = LinearInterpolation(x,y)
-    
+
     cdf_y = cumul_integrate(x,y)
     cdf_itp = LinearInterpolation(x,cdf_y)
     invcdf_itp = LinearInterpolation(cdf_y,x)
@@ -61,16 +61,9 @@ end
 get_knots(d::LinearInterpolatedPDF{T,1,ITP,BSpline{Linear}}) where {T,ITP} = first(d.pdf_itp.itp.ranges)
 get_knots(d::LinearInterpolatedPDF{T,1,ITP,Gridded{Linear}}) where {T,ITP} = first(d.pdf_itp.itp.knots)
 
-pdf(d::LinearInterpolatedPDF, x::T) where {T<:Real} = d.pdf_itp(x)
-cdf(d::LinearInterpolatedPDF, x::T) where {T<:Real} = d.cdf_itp(x)
-quantile(d::LinearInterpolatedPDF, x::T) where {T<:Real} = d.invcdf_itp(x)
-
-pdf(d::LinearInterpolatedPDF, x::AbstractVector{T}) where {T<:Real} = d.pdf_itp(x)
-cdf(d::LinearInterpolatedPDF, x::AbstractVector{T}) where {T<:Real} = d.cdf_itp(x)
-quantile(d::LinearInterpolatedPDF, x::AbstractVector{T}) where {T<:Real} = d.invcdf_itp(x)
-
-midpoints(x::AbstractRange) = range(first(x)+step(x)*(1//2), stop=last(x)-step(x)*(1//2), length=length(x)-1)
-midpoints(x::AbstractVector) = [(x[i]+x[i+1])*(1//2) for i in eachindex(x)[1:end-1]]
+Distributions.pdf(d::LinearInterpolatedPDF, x::Real) = d.pdf_itp(x)
+Distributions.cdf(d::LinearInterpolatedPDF, x::Real) = d.cdf_itp(x)
+Distributions.quantile(d::LinearInterpolatedPDF, x::Real) = d.invcdf_itp(x)
 
 """
     fit_cpl(x::AbstractArray, s::AbstractArray)
@@ -122,7 +115,7 @@ function fit_cpl(x::AbstractVector{XT}, s::AbstractVector{YT}) where {XT<:Real, 
     cdf_itp = LinearInterpolation(cdf_x,cdf_y)
 
     invcdf_itp = LinearInterpolation(cdf_y,cdf_x)
-    
+
     xmid = Vector{T}(undef,length(x)+1)
     xmid[1] = first(x)
     xmid[2:end-1] = midpoints(x)
@@ -134,6 +127,4 @@ function fit_cpl(x::AbstractVector{XT}, s::AbstractVector{YT}) where {XT<:Real, 
     return LinearInterpolatedPDF(x, p)
 end
 
-using Random
-import Base.rand
-rand(rng::AbstractRNG, d::LinearInterpolatedPDF) = d.invcdf_itp(rand(rng))
+Base.rand(rng::AbstractRNG, d::LinearInterpolatedPDF) = d.invcdf_itp(rand(rng))

--- a/src/linear_1d.jl
+++ b/src/linear_1d.jl
@@ -39,10 +39,10 @@ julia> quantile(d,0.5)
 1.8
 ```
 """
-struct LinearInterpolatedPDF{T,N,ITP,IT} <: ContinuousUnivariateDistribution
-    pdf_itp::Extrapolation{T,N,ITP,IT,Throw{Nothing}}
-    cdf_itp::Extrapolation{T,N,ITP,IT,Throw{Nothing}}
-    invcdf_itp::Extrapolation{T,N,<:GriddedInterpolation,<:Gridded{Linear},Throw{Nothing}}
+struct LinearInterpolatedPDF{P,C,I} <: ContinuousUnivariateDistribution
+    pdf_itp::P
+    cdf_itp::C
+    invcdf_itp::I
 end
 
 function LinearInterpolatedPDF(x, y)
@@ -58,8 +58,9 @@ function LinearInterpolatedPDF(x, y)
     return LinearInterpolatedPDF(pdf_itp, cdf_itp, invcdf_itp)
 end
 
-get_knots(d::LinearInterpolatedPDF{T,1,ITP,BSpline{Linear}}) where {T,ITP} = first(d.pdf_itp.itp.ranges)
-get_knots(d::LinearInterpolatedPDF{T,1,ITP,Gridded{Linear}}) where {T,ITP} = first(d.pdf_itp.itp.knots)
+Base.eltype(::Type{LinearInterpolatedPDF{P,C,I}}) where {P,C,I} = eltype(I)
+
+Interpolations.getknots(d::LinearInterpolatedPDF) = first(getknots(d.pdf_itp))
 
 Distributions.pdf(d::LinearInterpolatedPDF, x::Real) = d.pdf_itp(x)
 Distributions.cdf(d::LinearInterpolatedPDF, x::Real) = d.cdf_itp(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ Random.seed!(1234)
     @testset "UnitRange knots" begin
         x = 0:10
         d = fit_cpl(x, 10.0.*rand(10))
-        @test get_knots(d) == x
+        @test getknots(d) == x
 
         @test iszero(cdf(d, first(x)))
         @test isone(cdf(d, last(x)))
@@ -21,7 +21,7 @@ Random.seed!(1234)
     @testset "StepRangeLen knots" begin
         x = range(0, stop=5, length=10)
         d = fit_cpl(x, 5.0.*rand(10))
-        @test get_knots(d) == x
+        @test getknots(d) == x
 
         @test iszero(cdf(d, first(x)))
         @test isone(cdf(d, last(x)))
@@ -33,7 +33,7 @@ Random.seed!(1234)
     @testset "Vector knots" begin
         x = [0.0, 0.5, 1.0, 1.5, 2.0]
         d = fit_cpl(x, 2.0.*rand(10))
-        @test get_knots(d) == x
+        @test getknots(d) == x
 
         @test iszero(cdf(d, first(x)))
         @test isone(cdf(d, last(x)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,8 @@
 using InterpolatedPDFs
+using Random
 using Test
 
-import Random.seed!
-seed!(1234)
+Random.seed!(1234)
 
 @testset "linear_1d" begin
 
@@ -52,15 +52,15 @@ seed!(1234)
         @test isa(quantile(d,y), Float64)
 
         n = 10
-        y = pdf(d,2.0.*rand(n))
+        y = pdf.(Ref(d), 2 .* rand(n))
         @test isa(y, Vector{Float64})
         @test length(y) == n
 
-        y = cdf(d,2.0.*rand(n))
+        y = cdf.(Ref(d), 2 .* rand(n))
         @test isa(y, Vector{Float64})
         @test length(y) == n
 
-        y = quantile(d,rand(n))
+        y = quantile.(Ref(d), rand(n))
         @test isa(y, Vector{Float64})
         @test length(y) == n
     end
@@ -79,7 +79,7 @@ seed!(1234)
         x = range(0, stop=π/2, length=20)
         d = fit_cpl(x, acos.(rand(100000)))
         xmid = InterpolatedPDFs.midpoints(x)
-        @test maximum(abs.(pdf(d,xmid) .- sin.(xmid))) < 0.02
+        @test maximum(abs.(pdf.(Ref(d), xmid) .- sin.(xmid))) < 0.02
     end
 
     @testset "sampling" begin


### PR DESCRIPTION
This PR removes the dependency on Revise, uses `StatsBase.midpoints` which is duplicated in the current implementation (StatsBase is already an indirect dependency via Distributions), overloads existing methods such as `Distributions.quantile` instead of defining new ones, and removes the definition of `pdf` etc. for vectors which is deprecated in Distributions (instead Distributions advises to use broadcasting).